### PR TITLE
Fixes

### DIFF
--- a/datascroller/__init__.py
+++ b/datascroller/__init__.py
@@ -1,1 +1,1 @@
-from .scroller import pdscroller 
+from .scroller import * 

--- a/datascroller/__init__.py
+++ b/datascroller/__init__.py
@@ -1,0 +1,1 @@
+from .scroller import pdscroller 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -3,8 +3,8 @@ import curses
 import pandas as pd
 import time
 
-#--------
-# poor man's config file
+
+# poor man's config file ------------------------------------------------------
 ENTER = 10 
 QUIT = 113
 
@@ -20,8 +20,7 @@ RETRACT_COL = 97
 
 PAGE_DOWN = 6
 PAGE_UP = 2
-
-#--------
+#------------------------------------------------------------------------------
 
 
 def get_key_and_print(stdscr, disp_str):
@@ -34,54 +33,94 @@ def get_key_and_print(stdscr, disp_str):
         key = stdscr.getch()
     return key
 
-def pdscroller(df, width=5, height=8):
-    # Tunable Params
-    # Initialization
+
+def key_press_and_print_df(stdscr, df):
+    curses.curs_set(0)
+    max_yx = stdscr.getmaxyx() # NOTE: This does not change in real time
     last_row = df.shape[0] - 1
     last_col = df.shape[1] - 1
 
     # Initializing the window
     start_row = 0
-    end_row = min(height, last_row)
+    end_row = min(5, last_row,  max_yx[0] - 1) # TODO (ben): make configurable
     start_col = 0
-    end_col = min(width, last_col)
+    end_col = min(10, last_col)
 
-    key = -99
-    # The scroller loop
-    while key not in [ENTER, QUIT]: # Enter or 'q' quits (on my machine at least)
+    # Turn dataframe window into pritable string
+    df_window = df.iloc[start_row:end_row, start_col:end_col]
+    disp_str = df_window.to_string()
+    row_chars = len(disp_str.split('\n')[0])
+    while row_chars > max_yx[1] - 1:
+        end_col -= 1
         df_window = df.iloc[start_row:end_row, start_col:end_col]
-        key = curses.wrapper(get_key_and_print, df_window.to_string())
+        disp_str = df_window.to_string()
+        row_chars = len(disp_str.split('\n')[0])
+
+    stdscr.clear()
+    stdscr.addstr(0, 0, disp_str)
+    stdscr.refresh()
+
+    key = -1
+    # The scroller loop
+    while key not in [ENTER, QUIT]:
+
+        key = stdscr.getch()
+
         # Movement based on vim keys
         if key in [SCROLL_LEFT, curses.KEY_LEFT] and start_col > 0:
             start_col -= 1
             end_col -= 1
-        elif key in [SCROLL_RIGHT, curses.KEY_RIGHT] and start_col + width <= last_col:
+        elif key in [SCROLL_RIGHT, curses.KEY_RIGHT] and start_col < last_col:
             start_col += 1
             end_col += 1
-        elif key in [SCROLL_DOWN, curses.KEY_DOWN] and start_row + height <= last_row:
+        elif key in [SCROLL_DOWN, curses.KEY_DOWN] and start_row < last_row:
             start_row += 1
             end_row += 1
         elif key in [SCROLL_UP, curses.KEY_UP] and start_row > 0:
             start_row -= 1
             end_row -= 1
         # Window resizing
-        elif key == RETRACT_COL and end_col > 0: # Wind window back left - a key
+        elif key == RETRACT_COL and end_col > 0:
             end_col -= 1
-        elif key == EXPAND_COL and end_col <= last_col: # Extend window right - d key
+        elif key == EXPAND_COL and end_col < last_col:
             end_col += 1
-        elif key == EXPAND_ROW and end_row <= last_row: # Extend window down - x key
+        elif key == EXPAND_ROW and end_row < last_row:
             end_row += 1
-        elif key == RETRACT_ROW and end_row > 0: # Wind window back up - w key
+        elif key == RETRACT_ROW and end_row > 0:
             end_row -= 1
         # Moving fast
-        elif key == PAGE_DOWN and end_row + height <= last_row: # Ctrl + F
-            # TODO: allow for traveling the remainder
+        elif key == PAGE_DOWN and end_row < last_row:
+            height = end_row - start_row
             start_row += height
-            end_row += height
+            end_row += height 
 
-        elif key == PAGE_UP and start_row - height >= 0: # Ctrl + B
-            # TODO: allow for traveling the remainder
-            start_row -= height
-            end_row -= height
+        elif key == PAGE_UP and end_row - (end_row - start_row) >= 0:
+            height = end_row - start_row
+            start_row -= height 
+            end_row -= height 
+        # After all the if & elif statements, reprint and display
+        disp_str = df.iloc[start_row:end_row, start_col:end_col].to_string()
+        stdscr.clear()
+        stdscr.addstr(0, 0, disp_str)
+        stdscr.addstr(0, 0, 'R' + str(start_row))
+        stdscr.refresh()
 
-    #return df_window
+
+def scroll(scrollable):
+    if isinstance(scrollable, pd.core.frame.DataFrame):
+        curses.wrapper( key_press_and_print_df, scrollable)
+    else:
+        print('type ' + str(type(scrollable)) + ' not yet scrollable!')
+
+
+def main():
+    # This is how you run scroller2
+    #load_ext autoreload
+    #autoreload 2
+    #import pandas as pd
+    #from datascroller import scroll
+    train = pd.read_csv('resources/train.csv')
+    scroll(train)
+
+if __name__ == '__main__':
+    main()

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -1,24 +1,27 @@
 import os
 import curses
 import pandas as pd
+import time
+
+curses.noecho()
+curses.curs_set(0)
+curses.cbreak()
 
 def get_key_and_print(stdscr, disp_str):
-    curses.curs_set(0)
+    #curses.curs_set(0)
     stdscr.clear()
     stdscr.addstr(5, 5, disp_str)
     stdscr.refresh()
-    while True:
+    key = -1
+    while key == -1:
         key = stdscr.getch()
-        if key != -1:
-            break
     return key
 
-def scroller(df, width=5, height=8): # ignores df for now. Uses iris
+def pdscroller(df, width=5, height=8):
     # Tunable Params
     # Initialization
     last_row = df.shape[0] - 1
     last_col = df.shape[1] - 1
-    print(last_col)
 
     # Initializing the window
     start_row = 0
@@ -35,13 +38,13 @@ def scroller(df, width=5, height=8): # ignores df for now. Uses iris
         if key == 104 and start_col > 0: # h - vim key for left
             start_col -= 1
             end_col -= 1
-        elif key == 108 and start_col + width <= last_col: # l - vim key for right #TODO: rewrite condition in terms of end?
+        elif key == 108 and start_col + width <= last_col: # l - vim key right
             start_col += 1
             end_col += 1
-        elif key == 106 and start_row + height <= last_row: # j - vim key for down
+        elif key == 106 and start_row + height <= last_row: # j - vim key down
             start_row += 1
             end_row += 1
-        elif key == 107 and start_row > 0: # k - vim key for up
+        elif key == 107 and start_row > 0: # k - vim key up
             start_row -= 1
             end_row -= 1
         # Window resizing
@@ -64,4 +67,4 @@ def scroller(df, width=5, height=8): # ignores df for now. Uses iris
             start_row -= height
             end_row -= height
 
-    return df_window
+    #return df_window


### PR DESCRIPTION
- Addressed [Issue 2](https://github.com/baogorek/datascroller/issues/2) and [Issue 6](https://github.com/baogorek/datascroller/issues/6) about the error when the data frame string exceeded curses window dimension
- Addressed [Issue 8](https://github.com/baogorek/datascroller/issues/8) on long import statement
- Addressed [Issue 4](https://github.com/baogorek/datascroller/issues/4) on console ghosting.