### PR TITLE
Potential fix and conversation starter for integer columns

### DIFF
--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -345,7 +345,7 @@ def scroll(scrollable):
         print('type ' + str(type(scrollable)) + ' not yet scrollable!')
 
 def scroll_csv(csv_path):
-    pandas_df = pd.read_csv(csv_path)
+    pandas_df = pd.read_csv(csv_path, dtype=object)
     scroll(pandas_df)
 
 def main():


### PR DESCRIPTION
**Background:** this [issue](https://github.com/baogorek/datascroller/issues/21)

The below code "fixes" the ints-as-floats problem for `scroll_csv()`, but not the general `scroll()` function (I'm not sure there's an [easy way](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html) to do it if `scroll()` is called with an [existing dataframe](https://stackoverflow.com/questions/40251948/stop-pandas-from-converting-int-to-float/40252138)). In fact, it may not be the best, most general fix. @baogorek and @kjmerf I'd love to get your thoughts at some point on how to handle this. 

The worst case scenario, but I think still feasible, is that if `scroll()` is called on an existing dataframe instead of a CSV, we… I don't know, recreate it? That doesn't seem right... I also just want to hear from y'all how big of an issue you think this is, and whether it's acceptable to have different behavior between `scroll_csv()` and `scroll()`

Back to studying... 