### PR TITLE
Basic column header formatting

### DIFF
--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -16,6 +16,11 @@ SCROLL_UP = 107
 
 PAGE_DOWN = 6
 PAGE_UP = 2
+
+# The init_pair(n, f, b) function changes the definition of
+# color pair n, to foreground color f and background color b
+curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK);
+
 # ------------------------------------------------------------------------------
 
 
@@ -235,19 +240,12 @@ class ViewingArea:
     def _add_string_using_curses(self, screen, otherstring):
         """Prints strings for use with the scroller"""
 
-        # only necessary if we want to use color. First argument is an ID for
-        #   this pairing. Second and third are the text and background colors
-        #   respectively
-        curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK);
-
-        # for list of curses attributes, see http://tldp.org/HOWTO/NCURSES-Programming-HOWTO/attrib.html
         try:
             screen.addstr(self.topmost_char, self.leftmost_char,
-                          otherstring)
+                             otherstring)
             screen.chgat(self.topmost_char, self.leftmost_char,
-                          self.total_chars_x, curses.color_pair(1)
-                                            | curses.A_UNDERLINE
-                                            | curses.A_BOLD)
+                            self.total_chars_x, curses.color_pair(1)
+                            | curses.A_UNDERLINE | curses.A_BOLD)
         except curses.error:
             pass
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -234,9 +234,15 @@ class ViewingArea:
     # TODO(baogorek): figure out what to do with function above
     def _add_string_using_curses(self, screen, otherstring):
         """Prints strings for use with the scroller"""
+
+        curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK);
+
+        # for list of curses attributes, see http://tldp.org/HOWTO/NCURSES-Programming-HOWTO/attrib.html
         try:
             screen.addstr(self.topmost_char, self.leftmost_char,
                           otherstring)
+            screen.chgat(self.topmost_char, self.leftmost_char,
+                          self.total_chars_x, curses.color_pair(1) | curses.A_UNDERLINE | curses.A_BOLD)
         except curses.error:
             pass
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -16,11 +16,6 @@ SCROLL_UP = 107
 
 PAGE_DOWN = 6
 PAGE_UP = 2
-
-# The init_pair(n, f, b) function changes the definition of
-# color pair n, to foreground color f and background color b
-curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK);
-
 # ------------------------------------------------------------------------------
 
 
@@ -239,7 +234,11 @@ class ViewingArea:
     # TODO(baogorek): figure out what to do with function above
     def _add_string_using_curses(self, screen, otherstring):
         """Prints strings for use with the scroller"""
-
+        
+        # The init_pair(n, f, b) function changes the definition of
+        # color pair n, to foreground color f and background color b
+        curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK);
+        # NOTE: see http://tldp.org/HOWTO/NCURSES-Programming-HOWTO/attrib.html
         try:
             screen.addstr(self.topmost_char, self.leftmost_char,
                              otherstring)

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -245,7 +245,9 @@ class ViewingArea:
             screen.addstr(self.topmost_char, self.leftmost_char,
                           otherstring)
             screen.chgat(self.topmost_char, self.leftmost_char,
-                          self.total_chars_x, curses.color_pair(1) | curses.A_UNDERLINE | curses.A_BOLD)
+                          self.total_chars_x, curses.color_pair(1)
+                                            | curses.A_UNDERLINE
+                                            | curses.A_BOLD)
         except curses.error:
             pass
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -235,6 +235,9 @@ class ViewingArea:
     def _add_string_using_curses(self, screen, otherstring):
         """Prints strings for use with the scroller"""
 
+        # only necessary if we want to use color. First argument is an ID for
+        #   this pairing. Second and third are the text and background colors
+        #   respectively
         curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK);
 
         # for list of curses attributes, see http://tldp.org/HOWTO/NCURSES-Programming-HOWTO/attrib.html

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -244,8 +244,8 @@ class ViewingArea:
             screen.addstr(self.topmost_char, self.leftmost_char,
                              otherstring)
             screen.chgat(self.topmost_char, self.leftmost_char,
-                            self.total_chars_x, curses.color_pair(1)
-                            | curses.A_UNDERLINE | curses.A_BOLD)
+                         self.total_chars_x, curses.color_pair(1)
+                             | curses.A_UNDERLINE | curses.A_BOLD)
         except curses.error:
             pass
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -242,7 +242,7 @@ class ViewingArea:
             screen.addstr(self.topmost_char, self.leftmost_char,
                           otherstring)
             screen.chgat(self.topmost_char, self.leftmost_char,
-                          self.total_chars_x, curses.color_pair(1) | curses.A_UNDERLINE)
+                          self.total_chars_x, curses.color_pair(1) | curses.A_UNDERLINE | curses.A_BOLD)
         except curses.error:
             pass
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -242,7 +242,7 @@ class ViewingArea:
             screen.addstr(self.topmost_char, self.leftmost_char,
                           otherstring)
             screen.chgat(self.topmost_char, self.leftmost_char,
-                          self.total_chars_x, curses.color_pair(1) | curses.A_UNDERLINE | curses.A_BOLD)
+                          self.total_chars_x, curses.color_pair(1) | curses.A_UNDERLINE)
         except curses.error:
             pass
 


### PR DESCRIPTION
Wow, I accidentally made a lot of progress on #26 with minimal new code! 

My original plan was to separately print the first line of the screen with curses formatting options, and then print the rest of the screen below that. But the result was always a skewed first row that looked really bad.

Turns out there's a function called `chgat()` that allows you to print the entire screen as normal, and then go in and modify the formatting on a specific set of characters (in this case, the first row).

**I don't think we should merge this as is**. I mostly want to show y'all what's possible. The coloring especially is probably not desirable, but I encourage you to play around with it! As of now I think the bold + underline looks pretty good. The underlining in particular creates this cool effect of separating the headers from the data like you'd see in an actual table, although it does make the characters slightly harder to read. So maybe just underlining is the move here, or just bolding. Those seem to be our best options from [the list](http://tldp.org/HOWTO/NCURSES-Programming-HOWTO/attrib.html).

Excited to see what y'all think!