### PR TITLE
Version 1.3: Goto line, select columns, SQL querying, highlight mode, on-screen help

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ The following keys are currently supported:
   + Press `/`, then type your query (use 'df' as the table name)
   + e.g. `/SELECT AVG(age) AS average_age, sex, survived FROM df GROUP BY sex, survived`
   + Then press `Enter`
+  + Note that you can execute new queries against the data frame you just created, or go back
 
-- Return from query view
+- Return from query view to entire data frame
   + b
 
 - Exiting

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ The following keys are currently supported:
 - Search by line
   + Press `;`, then type a line number (e.g. `:1000`) and press `Enter`
 
-- Filter columns (NEVER MIND, MOVED ON)
-  + Press `/`, then type a comma-separated list of columns (e.g. `/name, age, survived`) and press `Enter`
+- Filter columns
+  + Press `.`, then type a comma-separated list of columns (e.g. `.name, age, survived`) and press `Enter`
 
 - SQL querying
   + Press `/`, then type your query (use 'df' as the table name)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following keys are currently supported:
   + Ctrl + B: Page up (not working as well for some reason)
 
 - Search by line
-  + Press `;`, then type a line number (e.g. `:1000` and press `Enter`
+  + Press `;`, then type a line number (e.g. `:1000`) and press `Enter`
 
 - Filter columns
   + Press `/`, then type a comma-separated list of columns (e.g. `/name, age, survived`) and press `Enter`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The following keys are currently supported:
   + Ctrl + F: Page down
   + Ctrl + B: Page up (not working as well for some reason)
 
+- Search by line
+  + Press `;`, then type a line number and press `Enter`
+
 - Exiting
   + q
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,19 @@ up to resemble Vim's edit mode.
 The following keys are currently supported:
 
 - Movement
-  + h: move to the left
-  + j: move down
-  + k: move up
-  + l: move left
+  + `h`: move to the left
+  + `j`: move down
+  + `k`: move up
+  + `l`: move left
 
 - Quick Movement
-  + Ctrl + F: Page down
-  + Ctrl + B: Page up (not working as well for some reason)
+  + `Ctrl + F`: Page down
+  + `Ctrl + B`: Page up (not working as well for some reason)
+
+- Highlight mode
+  + Press `,` to highlight the current line for easier horizontal reading.
+  + Scrolling up and down will move the highlight bar within the window
+  + Press `,` again to exit highlight mode
 
 - Search by line
   + Press `;`, then type a line number (e.g. `:1000`) and press `Enter`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following keys are currently supported:
   + Scrolling up and down will move the highlight bar within the window
   + Press `,` again to exit highlight mode
 
-- Search by line
+- Goto line
   + Press `;`, then type a line number (e.g. `:1000`) and press `Enter`
 
 - Filter columns
@@ -74,7 +74,7 @@ The following keys are currently supported:
   + Then press `Enter`
   + Note that you can execute new queries against the data frame you just created, or go back
 
-- Return from query view to entire data frame
+- Return from query/filter view to entire data frame
   + b
 
 - Exiting

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following keys are currently supported:
   + h: move to the left
   + j: move down
   + k: move up
-  + l: move left 
+  + l: move left
 
 - Quick Movement
   + Ctrl + F: Page down
@@ -59,6 +59,9 @@ The following keys are currently supported:
 
 - Search by line
   + Press `;`, then type a line number and press `Enter`
+
+- Filter columns
+  + Press `/`, then type a comma-separated list of columns (e.g. `/name, age, survived`) and press `Enter`
 
 - Exiting
   + q
@@ -109,7 +112,7 @@ def get_dataframe_window(self):
 ```
 DFWindow must be aware of the viewing area in order to set an appropriate value
 of `self.c_2`, and hence DFWindow requires an instance of ViewingArea for
-initialization. 
+initialization.
 ```
 import pandas as pd
 from datascroller.scroller import DFWindow

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The following keys are currently supported:
 - Exiting
   + q
 
+To see these keybindings at the top of the scroller screen, press `'`
+
 ### Examples
 
 Using iPython is a good way to try out datascroller interactively:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ The following keys are currently supported:
 - Exiting
   + q
 
-To see these keybindings at the top of the scroller screen, press `'`
-
 ### Examples
 
 Using iPython is a good way to try out datascroller interactively:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,16 @@ The following keys are currently supported:
 - Search by line
   + Press `;`, then type a line number (e.g. `:1000`) and press `Enter`
 
-- Filter columns
+- Filter columns (NEVER MIND, MOVED ON)
   + Press `/`, then type a comma-separated list of columns (e.g. `/name, age, survived`) and press `Enter`
+
+- SQL querying
+  + Press `/`, then type your query (use 'df' as the table name)
+  + e.g. `/SELECT AVG(age) AS average_age, sex, survived FROM df GROUP BY sex, survived`
+  + Then press `Enter`
+
+- Return from query view
+  + b
 
 - Exiting
   + q

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following keys are currently supported:
   + Ctrl + B: Page up (not working as well for some reason)
 
 - Search by line
-  + Press `;`, then type a line number and press `Enter`
+  + Press `;`, then type a line number (e.g. `:1000` and press `Enter`
 
 - Filter columns
   + Press `/`, then type a comma-separated list of columns (e.g. `/name, age, survived`) and press `Enter`

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -32,7 +32,6 @@ class DFWindow:
 
         self.rows_to_print = (self.viewing_area.bottommost_char -
                               self.viewing_area.topmost_char + 1)
-        self.cols_to_print = 0 # allows highlight mode to work better
 
         self.highlight_mode = False
         self.highlight_row, self.highlight_col = 0, 0
@@ -78,8 +77,7 @@ class DFWindow:
         self.r_1 = start_row
         self.c_1 = start_col
         self.r_2 = self.r_1 + self.rows_to_print
-        self.cols_to_print = self.find_last_fitting_column()
-        self.c_2 = self.c_1 + self.cols_to_print
+        self.c_2 = self.find_last_fitting_column()
 
     def show_data_window_in_viewing_area(self):  # start_row=0, start_col=0):
         self.viewing_area.show_curses_representation(
@@ -172,7 +170,7 @@ class DFWindow:
         self.highlight_mode = not self.highlight_mode
         # TODO maybe be smarter about this
         self.highlight_row, self.highlight_col = 0, 0
-        self.viewing_area.toggle_highlight_mode(self.build_position_list())
+        self.viewing_area.toggle_highlight_mode()
 
     def page_down(self):
         if self.r_2 < self.full_df.shape[0] - 1:
@@ -295,9 +293,9 @@ class ViewingArea:
             screen.chgat(self.topmost_char, self.leftmost_char,
                          self.total_chars_x, curses.color_pair(1)
                          | curses.A_UNDERLINE | curses.A_BOLD)
-#            if self.highlight_mode:
-#                screen.chgat(self.topmost_char + 1 + self.highlight_row, self.pad_chars_x,
-#                             self.rightmost_char, curses.A_STANDOUT)
+            if self.highlight_mode:
+                screen.chgat(self.topmost_char + 1 + self.highlight_row, self.pad_chars_x,
+                             self.rightmost_char, curses.A_STANDOUT)
         except curses.error:
             pass
 
@@ -354,9 +352,7 @@ class ViewingArea:
         """Same as above but does not refresh"""
         self._add_string_using_curses(screen, string)
 
-    def toggle_highlight_mode(self, position_list):
-        self.highlight_row, self.highlight_col = 0, 0
-        self.position_list = position_list
+    def toggle_highlight_mode(self):
         self.highlight_mode = not self.highlight_mode
 
     # NOTE(johncmerfeld): do not use yet

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -411,7 +411,7 @@ class ViewingArea:
 # TODO(johncmerfeld): this should respond dynamically to config file
 def get_help_string():
     help_string = ('Down/Up: j/k \t Left/Right: h/l \t Page Down/Up: ctrl+f/ctrl+b\t Quit: q\n' +
-                   'Line search: ;\t Query: /\t Exit query: b\t Highlight mode: ,\t Help menu: \'')
+                   'Line search: ;\t Query: /\t Exit query: b\t Highlight mode: ,\t Toggle help: \'')
 
     return help_string
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -25,10 +25,6 @@ QUERY           = 47 # '/'
 LINE_SEARCH     = 59 # ';'
 BACK            = 98 # 'b'
 # ------------------------------------------------------------------------------
-# Display constants (maybe shouldn't be configurable)
-HELP_INDENT = 30
-
-# ------------------------------------------------------------------------------
 
 
 class DFWindow:
@@ -410,8 +406,8 @@ class ViewingArea:
 
 # TODO(johncmerfeld): this should respond dynamically to config file
 def get_help_string():
-    help_string = ('Down/Up: j/k \t Left/Right: h/l \t Page Down/Up: ctrl+f/ctrl+b\t Quit: q\n' +
-                   'Line search: ;\t Query: /\t Exit query: b\t Highlight mode: ,\t Toggle help: \'')
+    help_string = ('Ver: j/k \t Hor: h/l \t Page Down/Up: ctrl+f/+b\t Quit: q\t Help: \'\n' +
+                   'Goto line: ;\t Filter: .\t Query: /\t Exit query/filter: b\t Highlight mode: ,')
 
     return help_string
 
@@ -468,7 +464,7 @@ def key_press_and_print_df(stdscr, df):
         # search functionality
         elif key == LINE_SEARCH:
             search_string = get_user_input_with_prompt(stdscr, term_rows - 1, 0,
-                                                       "Line search: ")
+                                                       "Goto line: ")
             if len(search_string) > 0:
                 try:
                     df_window.line_search(int(search_string))

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -501,8 +501,9 @@ def key_press_and_print_df(stdscr, df):
             df_window = DFWindow(df, viewing_area)
 
         elif key == curses.KEY_RESIZE:
-            print("Terminal resized. Please restart the scroller")
-            break
+            viewing_area = ViewingArea(8, 2)
+            df_window = DFWindow(df, viewing_area)
+            df_window.add_data_to_screen(stdscr)
 
         stdscr.clear()
         df_window.add_data_to_screen(stdscr)

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -3,7 +3,7 @@ import shutil
 import curses
 import pandas as pd
 import time
-
+from pandasql import sqldf
 
 # hard-coded config TODO(baogorek): allow config file -------------------------
 ENTER = 10
@@ -178,6 +178,10 @@ class DFWindow:
         raw_cols = query_string.split(",")
         cleaned_cols = [col.strip() for col in raw_cols]
         return DFWindow(self.full_df.filter(items = cleaned_cols), viewing_area)
+
+    def query2(self, query_string, viewing_area):
+        df = self.full_df
+        return DFWindow(sqldf(query_string, locals()), viewing_area)
 
 class ViewingArea:
     """ Class representing the viewing area where dataframes are printed
@@ -391,11 +395,11 @@ def key_press_and_print_df(stdscr, df):
 
         elif key == QUERY:
             query_bytes = get_user_input_with_prompt(stdscr, term_rows - 1, 0,
-                                                       "Column filter: ")
+                                                       "SQL query: ")
             query_string = query_bytes.decode(encoding="utf-8")
             if len(query_string) > 0:
                 try:
-                    df_window = df_window.query(query_string, viewing_area)
+                    df_window = df_window.query2(query_string, viewing_area)
                 except SyntaxError:
                     pass
                     # TODO(johncmerfeld): Reprimand the user?

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -1,8 +1,8 @@
 import sys
 import shutil
 import curses
-import pandas as pd
 import time
+import pandas as pd
 from pandasql import sqldf
 
 # hard-coded config TODO(baogorek): allow config file -------------------------

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -461,7 +461,8 @@ def key_press_and_print_df(stdscr, df):
             df_window.toggle_highlight_mode()
 
         elif key == HELP:
-            help_view = not help_view
+            #help_view = not help_view
+            pass
 
         # search functionality
         elif key == LINE_SEARCH:
@@ -502,6 +503,7 @@ def key_press_and_print_df(stdscr, df):
 
         elif key == curses.KEY_RESIZE:
             viewing_area = ViewingArea(8, 2)
+            term_cols, term_rows = viewing_area.get_terminal_size()
             df_window = DFWindow(df, viewing_area)
             df_window.add_data_to_screen(stdscr)
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -19,6 +19,7 @@ PAGE_UP = 2
 
 QUERY = 47 # '/'
 LINE_SEARCH = 59 # ';'
+BACK = 98 # 'b'
 # ------------------------------------------------------------------------------
 
 
@@ -26,8 +27,7 @@ class DFWindow:
     """The data frame window"""
 
     def __init__(self, pandas_df, viewing_area):
-        self.original_df = pandas_df
-        self.full_df = self.original_df
+        self.full_df = pandas_df
         (self.total_rows, self.total_cols) = pandas_df.shape
 
         self.viewing_area = viewing_area
@@ -174,9 +174,10 @@ class DFWindow:
         self.update_dataframe_coords(start_row=new_start_row,
                                      start_col=self.c_1)
 
-    def query(self, query):
-        # MAKE ME
-        return
+    def query(self, query_string, viewing_area):
+        raw_cols = query_string.split(",")
+        cleaned_cols = [col.strip() for col in raw_cols]
+        return DFWindow(self.full_df.filter(items = cleaned_cols), viewing_area)
 
 class ViewingArea:
     """ Class representing the viewing area where dataframes are printed
@@ -389,14 +390,19 @@ def key_press_and_print_df(stdscr, df):
                     # TODO(johncmerfeld): Reprimand the user?
 
         elif key == QUERY:
-            query_string = get_user_input_with_prompt(stdscr, term_rows - 1, 0,
-                                                       "Pandas query: ")
+            query_bytes = get_user_input_with_prompt(stdscr, term_rows - 1, 0,
+                                                       "Column filter: ")
+            query_string = query_bytes.decode(encoding="utf-8")
             if len(query_string) > 0:
                 try:
-                    df_window.query(query_string)
+                    df_window = df_window.query(query_string, viewing_area)
                 except SyntaxError:
                     pass
                     # TODO(johncmerfeld): Reprimand the user?
+
+        elif key == BACK:
+            # exit query mode, essentially
+            df_window = DFWindow(df, viewing_area)
 
         elif key == curses.KEY_RESIZE:
             print("Terminal resized. Please restart the scroller")

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -34,7 +34,7 @@ class DFWindow:
                               self.viewing_area.topmost_char + 1)
 
         self.highlight_mode = False
-        self.highlight_row, self.highlight_col = 0, 0
+        self.highlight_row = 0
 
         self.update_dataframe_coords()
 
@@ -168,8 +168,6 @@ class DFWindow:
 
     def toggle_highlight_mode(self):
         self.highlight_mode = not self.highlight_mode
-        # TODO maybe be smarter about this
-        self.highlight_row, self.highlight_col = 0, 0
         self.viewing_area.toggle_highlight_mode()
 
     def page_down(self):
@@ -247,7 +245,7 @@ class ViewingArea:
         self.bottommost_char = self.total_chars_y - pad_y - 1
 
         self.highlight_mode = False
-        self.highlight_row, self.highlight_col = 0, 0
+        self.highlight_row = 0
 
     def _create_list_of_rowstrings(self):
         """prints a representation of the viewing area to aid understanding"""
@@ -355,10 +353,10 @@ class ViewingArea:
     def toggle_highlight_mode(self):
         self.highlight_mode = not self.highlight_mode
 
-    # NOTE(johncmerfeld): do not use yet
+    # NOTE(johncmerfeld): for single-cell highlighting -- do not use yet
     def move_highlight_left(self):
         self.highlight_col -= 1
-    # NOTE(johncmerfeld): do not use yet
+    # NOTE(johncmerfeld): for single-cell highlighting -- do not use yet
     def move_highlight_right(self):
         self.highlight_col += 1
 

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -244,6 +244,9 @@ class ViewingArea:
             row_list.append('P' * self.total_chars_x)
         return row_list
 
+    def get_terminal_size(self):
+        return self.total_chars_x, self.total_chars_y
+
     def print_representation(self):
         rowlist = self._create_list_of_rowstrings()
         for j in range(self.total_chars_y - 1):
@@ -337,11 +340,19 @@ def key_press_and_print_df(stdscr, df):
     # stdscr = curses.initscr()
     stdscr.clear()
     viewing_area = ViewingArea(8, 2)
+    term_cols, term_rows = viewing_area.get_terminal_size()
     df_window = DFWindow(df, viewing_area)
 
     df_window.add_data_to_screen(stdscr)
     stdscr.addstr(0, 0, df_window.get_location_string())
     stdscr.refresh()
+
+    def my_raw_input(stdscr, r, c, prompt_string):
+        curses.echo()
+        stdscr.addstr(r, c, prompt_string)
+        stdscr.refresh()
+        input = stdscr.getstr(r, c + len(prompt_string), 20)
+        return input  #       ^^^^  reading input at next column
 
     key = -1
     # The scroller loop
@@ -364,7 +375,8 @@ def key_press_and_print_df(stdscr, df):
 
         # search functionality
         elif key == LINE_SEARCH:
-            df_window.line_search(int(stdscr.getstr(0,0)))
+            curses.echo()
+            df_window.line_search(int(my_raw_input(stdscr, term_rows - 1, 0, "Line search: ")))
         elif key == curses.KEY_RESIZE:
             print("Terminal resized. Please restart the scroller")
             break

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -85,6 +85,17 @@ class DFWindow:
         self.r_2 = self.r_1 + self.rows_to_print
         self.c_2 = self.find_last_fitting_column()
 
+    def update_viewing_area(self, viewing_area):
+        """Update viewing area. Useful if terminal is resized while
+        user is viewing a subset of the original dataframe"""
+        self.viewing_area = viewing_area
+
+        self.rows_to_print = (self.viewing_area.bottommost_char -
+                              self.viewing_area.topmost_char + 1)
+
+        # update current view before accepting new input
+        self.update_dataframe_coords(self.r_1, self.c_1)
+
     def show_data_window_in_viewing_area(self):  # start_row=0, start_col=0):
         self.viewing_area.show_curses_representation(
             self.get_window_string())
@@ -504,7 +515,7 @@ def key_press_and_print_df(stdscr, df):
         elif key == curses.KEY_RESIZE:
             viewing_area = ViewingArea(8, 2)
             term_cols, term_rows = viewing_area.get_terminal_size()
-            df_window = DFWindow(df, viewing_area)
+            df_window.update_viewing_area(viewing_area)
             df_window.add_data_to_screen(stdscr)
 
         stdscr.clear()

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -175,7 +175,8 @@ class DFWindow:
                                      start_col=self.c_1)
 
     def query(self, query):
-
+        # MAKE ME
+        return
 
 class ViewingArea:
     """ Class representing the viewing area where dataframes are printed

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -415,7 +415,9 @@ def get_user_input_with_prompt(stdscr, row, col, prompt):
     curses.echo()
     stdscr.addstr(row, col, prompt)
     stdscr.refresh()
+    curses.curs_set(1)
     input = stdscr.getstr(row, col + len(prompt))
+    curses.curs_set(0)
     return input  #            ^^^^  reading input at next column
 
 def key_press_and_print_df(stdscr, df):

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -16,6 +16,9 @@ SCROLL_UP = 107
 
 PAGE_DOWN = 6
 PAGE_UP = 2
+
+QUERY = 47 # '/'
+LINE_SEARCH = 59 # ';'
 # ------------------------------------------------------------------------------
 
 
@@ -156,6 +159,19 @@ class DFWindow:
         self.update_dataframe_coords(start_row=self.r_1 - page_size,
                                      start_col=self.c_1)
 
+    def line_search(self, line):
+        new_start_row = 0
+        if line <= 0:
+            # go to top
+            pass
+        elif line >= self.full_df.shape[0] - self.rows_to_print:
+            # go to bottom
+            new_start_row = self.full_df.shape[0] - self.rows_to_print
+        else:
+            new_start_row = line
+
+        self.update_dataframe_coords(start_row=new_start_row,
+                                     start_col=self.c_1)
 
 class ViewingArea:
     """ Class representing the viewing area where dataframes are printed
@@ -345,6 +361,10 @@ def key_press_and_print_df(stdscr, df):
             df_window.page_down()
         elif key == PAGE_UP:
             df_window.page_up()
+
+        # search functionality
+        elif key == LINE_SEARCH:
+            df_window.line_search(int(stdscr.getstr(0,0)))
         elif key == curses.KEY_RESIZE:
             print("Terminal resized. Please restart the scroller")
             break

--- a/datascroller/scroller.py
+++ b/datascroller/scroller.py
@@ -17,9 +17,10 @@ SCROLL_UP = 107
 PAGE_DOWN = 6
 PAGE_UP = 2
 
-QUERY = 47 # '/'
-LINE_SEARCH = 59 # ';'
-BACK = 98 # 'b'
+FILTER = 46         # '.'
+QUERY = 47          # '/'
+LINE_SEARCH = 59    # ';'
+BACK = 98           # 'b'
 # ------------------------------------------------------------------------------
 
 
@@ -174,14 +175,21 @@ class DFWindow:
         self.update_dataframe_coords(start_row=new_start_row,
                                      start_col=self.c_1)
 
-    def query(self, query_string, viewing_area):
+    def filter(self, query_string, viewing_area):
         raw_cols = query_string.split(",")
         cleaned_cols = [col.strip() for col in raw_cols]
         return DFWindow(self.full_df.filter(items = cleaned_cols), viewing_area)
 
-    def query2(self, query_string, viewing_area):
+    def query(self, query_string, viewing_area):
         df = self.full_df
         return DFWindow(sqldf(query_string, locals()), viewing_area)
+
+        # in progress
+        ## this rigamarole means the user can use any table name they want
+        #    query_words = query_string.lower().split()
+        #    from_index = query_words.index("from")
+        #    table_name = query_words[from_index + 1]
+        #    exec("%s = %d" % (table_name, self.full_df))
 
 class ViewingArea:
     """ Class representing the viewing area where dataframes are printed
@@ -393,13 +401,24 @@ def key_press_and_print_df(stdscr, df):
                     pass
                     # TODO(johncmerfeld): Reprimand the user?
 
-        elif key == QUERY:
+        elif key == FILTER:
             query_bytes = get_user_input_with_prompt(stdscr, term_rows - 1, 0,
-                                                       "SQL query: ")
+                                                       "Column filter: ")
             query_string = query_bytes.decode(encoding="utf-8")
             if len(query_string) > 0:
                 try:
-                    df_window = df_window.query2(query_string, viewing_area)
+                    df_window = df_window.filter(query_string, viewing_area)
+                except pandasql.sqldf.PandaSQLException: # TODO better exception handling
+                    pass
+                    # TODO(johncmerfeld): Reprimand the user?
+
+        elif key == QUERY:
+            query_bytes = get_user_input_with_prompt(stdscr, term_rows - 1, 0,
+                                                       "SQL query (use 'df' as table name): ")
+            query_string = query_bytes.decode(encoding="utf-8")
+            if len(query_string) > 0:
+                try:
+                    df_window = df_window.query(query_string, viewing_area)
                 except SyntaxError:
                     pass
                     # TODO(johncmerfeld): Reprimand the user?

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ipython-genutils==0.2.0
 jedi==0.15.1
 numpy==1.17.3
 pandas==0.25.2
+pandasql==0.7.3
 parso==0.5.1
 pexpect==4.7.0
 pickleshare==0.7.5

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='datascroller',
     packages=['datascroller'],
-    version='1.2.0',
+    version='1.3.0',
     license='MIT',
     description='Data scrolling in the terminal',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         'pandas',
         'windows-curses ; platform_system=="Windows"',
+	'pandasql'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
I kind of got into a zone last night and today, so here are some upgrades to the scroller interface. **If we don't feel like some or all of these features are ready for prime time, all we need to do is remove the keybinding.** 

This PR addresses issues #9, and #30. 

Excuse my bravado on the version number change, but it felt unambiguously like new functionality.

## Goto line
Added an input key for a Vim-like goto feature. Currently, pressing the semicolon key (`;`) displays a prompt at the bottom of the screen. The user can enter a number and the window will attempt to move to put that line number at the top of the frame. If the line number is less than 0, the window will simply move to the top of the dataframe. If the line is greater than the number of rows, the window will move to the bottom of the dataframe. If the user presses enter without entering a number, or if they enter a non-numeric string, goto-line mode exits with no effects.
<img width="403" alt="image" src="https://user-images.githubusercontent.com/11447044/73227421-83509f00-4141-11ea-9ddd-b457211b1bd2.png">


## Column filter
Added an input key for a basic interface to Pandas' `filter` function. Currently, pressing the period key (`.`) displays a prompt at the bottom of the screen. The user enters a column-separated list of column names, and all other columns will be dropped from the display. Pressing `b` will return to the full view. Filtering on non-existent columns returns an empty dataframe. 
<img width="442" alt="image" src="https://user-images.githubusercontent.com/11447044/73227439-982d3280-4141-11ea-8127-58c755a25819.png">


## Query mode
Added a semi-experimental attachment to pandasql so the user can manipulate the table with full  querying (SQLite) powers. Pressing slash (`/`) will display a prompt at the bottom of the screen. Currently, the FROM clause requires `df` to be used as the table name, but we can probably work around that in future. So far I haven't found any way to break this besides trying an illegal query. 
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/11447044/73227617-0c67d600-4142-11ea-956d-3329a4916261.png">


## Highlight mode
Another semi-experimental feature is pressing the comma key (`,`) to highlight a row. Scrolling in highlight mode will move the highlighted row on the current screen until you hit the bottom or the top, at which point normal scrolling resumes. I thought this might be helpful for looking at a single row across a wide dataframe. Tried for a few hours to get it to work on single-cell highlighting, a la Excel, but it was very buggy. Still, definitely possible in a future iteration.
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/11447044/73227476-ae3af300-4141-11ea-8443-9d0c6b894a76.png">

## Handling terminal resize
Sorry to pile so much in here, but a small tweak to the `key_press_and_print_df()` function allows us to gracefully handle terminal resizing (i.e. using + and - to zoom in and out). Give it a try!

## Lastly, the README probably needs an overhaul but I updated it to include these new features.
There's a lot to sift through. I'm hoping we can all just play with this for a couple of weeks and see how we like it. Maybe it's a little overloaded, although I find the ease of use and performance to still be good. A lot of these features are at "phase 1" right now, but I do think they're integrated reasonably well into the existing code structure. Please make whatever suggestions, tweaks, and rollbacks you want!

## Help (will be removed from PR)
Pressing single-quote (`'`) will display a help bar at the top of the screen instead of the "location string." I tried really hard to keep this brief, so that it fits on two lines even for displays with very few characters per row. But it could use some cleaning up. Or maybe just a totally separate screen from the scroller so that we can spread out. More like a `man` page. Come to think of it, that's probably ideal. But this is a start.
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/11447044/73227375-62884980-4141-11ea-8ba4-73237e78fedd.png">
