### PR TITLE
Hotfix for broken scroll_demo 

### DIFF
--- a/datascroller/command_line.py
+++ b/datascroller/command_line.py
@@ -26,13 +26,13 @@ def run_getkey():
 
 
 def run_demo():
-    df = demo.read_titanic()
+    df = demo.read_titanic_csv()
     scroll(df)
 
 
 def create_parser():
     parser = argparse.ArgumentParser(
-        description="""Scroll a CSV from the command line with datascroller
+        description="""Scroll a CSV or parquet from the command line with datascroller
 
             The following keys are currently supported:
             # Movement

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ For more info, please see our github page: github.com/baogorek/datascroller
 setup(
     name='datascroller',
     packages=['datascroller'],
-    version='1.4.0',
+    version='1.4.1',
     license='MIT',
     description='Data scrolling in the terminal',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
The `read_titanic()` method was split into `read_titanic_csv()` and `read_titanic_parquet()`, but the name wasn't changed in the `scroll_demo` entry point. This has been fixed.